### PR TITLE
Fix backend token verification and order fetching

### DIFF
--- a/BE-food-delivery/controllers/order/get-order-by-userId.ts
+++ b/BE-food-delivery/controllers/order/get-order-by-userId.ts
@@ -6,7 +6,7 @@ export const getOrdersByUsersId = async (_req: Request, res: Response) => {
   try {
     const allOrdersUserById = await FoodOrderModel.find({
       user: userId,
-    }).populate("foodOrderItem");
+    }).populate("foodOrderItems.food");
     res.status(200).send({ order: allOrdersUserById });
   } catch (err) {
     res.status(400).send({ message: "Cannot Get Orders" });

--- a/BE-food-delivery/index.ts
+++ b/BE-food-delivery/index.ts
@@ -11,8 +11,8 @@ const app = express();
 
 app.use(cors());
 app.use(express.json());
-app.use("/routes/auth", authRoutes);
-app.use("/routes/order", OrderRouter);
+app.use("/api/auth", authRoutes);
+app.use("/api/order", OrderRouter);
 
 connectDB().catch((err) => {
   console.error("❌ Failed to connect to database:", err);

--- a/BE-food-delivery/models/Order.ts
+++ b/BE-food-delivery/models/Order.ts
@@ -22,7 +22,7 @@ type FoodOrderModelType = {
 const FoodOrderItemSchema = new Schema<FoodOrderItemModelType>(
   {
     quantity: { type: Number, required: true },
-    food: { type: Schema.Types.ObjectId, ref: "Foods", required: true },
+    food: { type: Schema.Types.ObjectId, ref: "Food", required: true },
   },
   { _id: false }
 );

--- a/BE-food-delivery/utils/jwt.ts
+++ b/BE-food-delivery/utils/jwt.ts
@@ -3,14 +3,16 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-const JWT_SECRET = process.env.JWT_SECRET;
+const JWT_SECRET = process.env.JWT_SECRET as string | undefined;
 
 if (!JWT_SECRET) {
   throw new Error("❌ JWT_SECRET is not defined in .env");
 }
 
 export const createToken = (payload: object) => {
-  return jwt.sign(payload, JWT_SECRET, {
-    expiresIn: process.env.JWT_EXPIRES_IN || "7d",
-  });
+  return jwt.sign(
+    payload,
+    JWT_SECRET as string,
+    { expiresIn: process.env.JWT_EXPIRES_IN || "7d" } as jwt.SignOptions
+  );
 };

--- a/BE-food-delivery/utils/token-checker.ts
+++ b/BE-food-delivery/utils/token-checker.ts
@@ -1,5 +1,8 @@
 import { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 export const tokenChecker = async (
   request: Request,
@@ -14,7 +17,11 @@ export const tokenChecker = async (
   }
   const token = authorization.split(" ")[1];
 
-  const tokenPassword = "foodDelivery";
+  const tokenPassword = process.env.JWT_SECRET;
+  if (!tokenPassword) {
+    response.status(500).send({ message: "JWT secret not configured" });
+    return;
+  }
   try {
     const isValid = jwt.verify(token, tokenPassword);
     if (isValid) {


### PR DESCRIPTION
## Summary
- verify JWT tokens with the configured secret
- fix path for food population when fetching orders
- correct Food reference in order model
- expose API routes under `/api` prefix
- ensure JWT helper uses correct types

## Testing
- `npx tsc --noEmit -p BE-food-delivery/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_685a54f9adc88333b9303397faceec4a