### PR TITLE
Fix order route method and add status update

### DIFF
--- a/BE-food-delivery/controllers/order/update-order-status.ts
+++ b/BE-food-delivery/controllers/order/update-order-status.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from "express";
+import { FoodOrderModel } from "../../models/Order";
+import { FoodOrderStatusEnum } from "../../enums/FoodOrderStatusEnum";
+
+export const updateOrderStatus = async (req: Request, res: Response) => {
+  const { orderId, status } = req.body;
+
+  if (!orderId || !status) {
+    res.status(400).send({ message: "Order id and status are required" });
+    return;
+  }
+
+  if (!Object.values(FoodOrderStatusEnum).includes(status)) {
+    res.status(400).send({ message: "Invalid status" });
+    return;
+  }
+
+  try {
+    const order = await FoodOrderModel.findByIdAndUpdate(
+      orderId,
+      { status },
+      { new: true }
+    );
+
+    if (!order) {
+      res.status(404).send({ message: "Order not found" });
+      return;
+    }
+
+    res.status(200).send({ order });
+  } catch (err) {
+    res.status(500).send({ message: "Failed to update status" });
+  }
+};

--- a/BE-food-delivery/routes/order.route.ts
+++ b/BE-food-delivery/routes/order.route.ts
@@ -3,10 +3,12 @@ import { Router } from "express";
 import { tokenChecker } from "../utils/token-checker";
 import { createOrder } from "../controllers/order/create-order";
 import { getOrdersByUsersId } from "../controllers/order/get-order-by-userId";
+import { updateOrderStatus } from "../controllers/order/update-order-status";
 
 const OrderRouter = Router();
 
 OrderRouter.post("/createOrder", tokenChecker, createOrder);
-OrderRouter.put("/getOrders", tokenChecker, getOrdersByUsersId);
+OrderRouter.get("/getOrders", tokenChecker, getOrdersByUsersId);
+OrderRouter.patch("/updateStatus", tokenChecker, updateOrderStatus);
 
 export default OrderRouter;


### PR DESCRIPTION
## Summary
- switch GET for retrieving orders
- add route to update order status
- implement `updateOrderStatus` controller

## Testing
- `npm run build --prefix BE-food-delivery`
- `npm run lint --prefix fe-food-delivery` *(fails: `next` not found)*
- `npm run build --prefix fe-food-delivery` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a66475c9883339ab086f088560d0f