### PR TITLE
Fix admin food menu navigation

### DIFF
--- a/fe-food-delivery/src/app/admin/menu/page.tsx
+++ b/fe-food-delivery/src/app/admin/menu/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { FoodMenuSection } from "../../_components/FoodMenuSection";
+
+export default function AdminFoodMenuPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold mb-4">Food menu</h1>
+      <FoodMenuSection />
+    </div>
+  );
+}

--- a/fe-food-delivery/src/app/admin/orders/AdminOrdersPage.tsx
+++ b/fe-food-delivery/src/app/admin/orders/AdminOrdersPage.tsx
@@ -7,6 +7,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "lucide-react";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import api from "@/lib/api";
 
 export type OrderStatus = "Pending" | "Delivered" | "Canceled";
@@ -27,6 +28,7 @@ export interface OrderItem {
 
 export default function AdminOrdersPage() {
   const [orders, setOrders] = useState<OrderItem[]>([]);
+  const router = useRouter();
 
   const handleStatusChange = async (id: string, status: OrderStatus) => {
     try {
@@ -69,8 +71,8 @@ export default function AdminOrdersPage() {
       <aside className="w-[260px] bg-white border-r p-6 flex flex-col gap-6">
         <div className="text-2xl font-bold text-red-500">NomNom</div>
         <nav className="flex flex-col gap-2 text-gray-700">
-          <Button> Orders</Button>
-          <Button> Food menu</Button>
+          <Button onClick={() => router.push("/admin")}>Orders</Button>
+          <Button onClick={() => router.push("/admin/menu")}>Food menu</Button>
         </nav>
       </aside>
 


### PR DESCRIPTION
## Summary
- enable router navigation in `AdminOrdersPage`
- add `/admin/menu` route with a basic menu page

## Testing
- `npm run lint --prefix fe-food-delivery` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7168fd688333a2674725290e1eb7