### PR TITLE
Store user id in localStorage after login

### DIFF
--- a/fe-food-delivery/src/app/login/_components/Login.tsx
+++ b/fe-food-delivery/src/app/login/_components/Login.tsx
@@ -36,6 +36,8 @@ export const Login = ({ onBack }: LoginProps) => {
           });
 
           localStorage.setItem("token", res.data.token);
+          // store logged in user's id
+          localStorage.setItem("userId", res.data.user._id);
           alert("Login successful! Welcome back.");
           router.push("/");
         } catch (err: any) {


### PR DESCRIPTION
## Summary
- persist logged in user's id alongside the auth token

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b589bc14c8333938ebf171d9dd5fc