### PR TITLE
Fix order status types

### DIFF
--- a/BE-food-delivery/controllers/order/get-order-by-userId.ts
+++ b/BE-food-delivery/controllers/order/get-order-by-userId.ts
@@ -6,7 +6,9 @@ export const getOrdersByUsersId = async (_req: Request, res: Response) => {
   try {
     const allOrdersUserById = await FoodOrderModel.find({
       user: userId,
-    });
+    })
+      .populate("user")
+      .sort({ createdAt: -1 });
     res.status(200).send({ order: allOrdersUserById });
   } catch (err) {
     res.status(400).send({ message: "Cannot Get Orders" });

--- a/fe-food-delivery/src/app/_components/CartDrawer.tsx
+++ b/fe-food-delivery/src/app/_components/CartDrawer.tsx
@@ -25,11 +25,13 @@ export default function CartDrawer({ children }: { children?: ReactNode }) {
     0
   );
 
+  type OrderStatus = "PENDING" | "DELIVERED" | "CANCELED";
+
   type Order = {
     id: string;
     date: string;
     total: number;
-    status: string;
+    status: OrderStatus;
     items: string[];
   };
 
@@ -43,7 +45,7 @@ export default function CartDrawer({ children }: { children?: ReactNode }) {
           id: o._id,
           date: new Date(o.createdAt).toLocaleDateString(),
           total: o.totalPrice,
-          status: o.status,
+          status: o.status as OrderStatus,
           items: o.foodOrderItems.map((i: any) => i.name),
         }));
         setOrders(data);
@@ -190,9 +192,11 @@ export default function CartDrawer({ children }: { children?: ReactNode }) {
                       </p>
                       <span
                         className={`text-xs px-2 py-1 rounded-full ${
-                          order.status === "Pending"
+                          order.status === "PENDING"
                             ? "bg-orange-100 text-orange-600"
-                            : "bg-green-100 text-green-600"
+                            : order.status === "DELIVERED"
+                            ? "bg-green-100 text-green-600"
+                            : "bg-red-100 text-red-600"
                         }`}
                       >
                         {order.status}
@@ -246,7 +250,7 @@ export default function CartDrawer({ children }: { children?: ReactNode }) {
                 id: o._id,
                 date: new Date(o.createdAt).toLocaleDateString(),
                 total: o.totalPrice,
-                status: o.status,
+                status: o.status as OrderStatus,
                 items: o.foodOrderItems.map((i: any) => i.name),
               }));
               setOrders(data);

--- a/fe-food-delivery/src/app/admin/orders/AdminOrdersPage.tsx
+++ b/fe-food-delivery/src/app/admin/orders/AdminOrdersPage.tsx
@@ -10,7 +10,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import api from "@/lib/api";
 
-export type OrderStatus = "Pending" | "Delivered" | "Canceled";
+export type OrderStatus = "PENDING" | "DELIVERED" | "CANCELED";
 
 export interface OrderItem {
   _id: string;


### PR DESCRIPTION
## Summary
- align order status strings with backend constants
- show correct badge colors for order history
- populate user and sort orders by creation date

## Testing
- `npm run build --prefix BE-food-delivery`
- `npm run build --prefix fe-food-delivery` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cae7e9be48333a38fc71d43e622d2