### PR TITLE
Add admin food menu and server API

### DIFF
--- a/BE-food-delivery/controllers/food/create-food.ts
+++ b/BE-food-delivery/controllers/food/create-food.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from "express";
+import { Food } from "../../models/Food";
+import mongoose from "mongoose";
+
+export const createFood = async (req: Request, res: Response) => {
+  try {
+    const { foodName, price, image, ingriedents, category } = req.body;
+    const food = await Food.create({
+      _id: new mongoose.Types.ObjectId(),
+      foodName,
+      price,
+      image,
+      ingriedents,
+      category,
+    });
+    res.status(200).send({ food });
+  } catch (err) {
+    console.error("Failed to create food", err);
+    res.status(500).send({ message: "Failed to create food" });
+  }
+};

--- a/BE-food-delivery/controllers/food/get-all-food.ts
+++ b/BE-food-delivery/controllers/food/get-all-food.ts
@@ -1,0 +1,12 @@
+import { Request, Response } from "express";
+import { Food } from "../../models/Food";
+
+export const getAllFood = async (_req: Request, res: Response) => {
+  try {
+    const foods = await Food.find();
+    res.status(200).send({ foods });
+  } catch (err) {
+    console.error("Failed to fetch foods", err);
+    res.status(500).send({ message: "Failed to fetch foods" });
+  }
+};

--- a/BE-food-delivery/index.ts
+++ b/BE-food-delivery/index.ts
@@ -4,6 +4,7 @@ import dotenv from "dotenv";
 import authRoutes from "./routes/auth.routes";
 import { connectDB } from "./db";
 import OrderRouter from "./routes/order.route";
+import FoodRouter from "./routes/food.route";
 
 dotenv.config();
 
@@ -13,6 +14,7 @@ app.use(cors());
 app.use(express.json());
 app.use("/api/auth", authRoutes);
 app.use("/api/order", OrderRouter);
+app.use("/api/food", FoodRouter);
 
 connectDB().catch((err) => {
   console.error("❌ Failed to connect to database:", err);

--- a/BE-food-delivery/routes/food.route.ts
+++ b/BE-food-delivery/routes/food.route.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { getAllFood } from "../controllers/food/get-all-food";
+import { createFood } from "../controllers/food/create-food";
+import { tokenChecker } from "../utils/token-checker";
+
+const FoodRouter = Router();
+
+FoodRouter.get("/", getAllFood);
+FoodRouter.post("/", tokenChecker, createFood);
+
+export default FoodRouter;

--- a/fe-food-delivery/src/app/admin/layout.tsx
+++ b/fe-food-delivery/src/app/admin/layout.tsx
@@ -1,4 +1,4 @@
-import { NavBar } from "./_components/navbar";
+import { NavBar } from "./_components/Navbar";
 
 export default function AdminLayout({
   children,

--- a/fe-food-delivery/src/app/admin/menu/page.tsx
+++ b/fe-food-delivery/src/app/admin/menu/page.tsx
@@ -1,11 +1,51 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import api from "@/lib/api";
+
 export default function AdminFoodMenuPage() {
+  const [foods, setFoods] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    async function fetchFoods() {
+      try {
+        setLoading(true);
+        const res = await api.get("/food");
+        setFoods(res.data.foods);
+      } catch (err) {
+        console.error("Failed to fetch foods", err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchFoods();
+  }, []);
+
   return (
     <div className="flex h-screen bg-gray-100 text-sm">
-      {/* Main Content */}
       <main className="flex-1 p-8 overflow-y-auto">
         <h1 className="text-xl font-semibold mb-4">Food menu</h1>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {loading ? (
+            <p>Loading...</p>
+          ) : foods.length === 0 ? (
+            <p>No food items.</p>
+          ) : (
+            foods.map((food) => (
+              <div key={food._id} className="bg-white p-4 rounded shadow">
+                <img
+                  src={food.image}
+                  alt={food.foodName}
+                  className="h-40 w-full object-cover rounded"
+                />
+                <h3 className="mt-2 font-semibold">{food.foodName}</h3>
+                <p className="text-sm text-gray-600">{food.ingriedents}</p>
+                <p className="font-bold">${food.price?.toFixed?.(2) ?? food.price}</p>
+              </div>
+            ))
+          )}
+        </div>
       </main>
     </div>
   );

--- a/fe-food-delivery/src/app/admin/page.tsx
+++ b/fe-food-delivery/src/app/admin/page.tsx
@@ -1,33 +1,9 @@
-import AdminFoodMenuPage from "./menu/page";
-import AdminOrdersPage from "./_components/board";
-import { Button } from "@/components/ui/button";
-import { Calendar } from "lucide-react";
+import Board from "./_components/board";
 
 const AdminPage = () => {
   return (
-    <div className="flex h-screen bg-gray-100 text-sm">
-      <main className="flex-1 p-8 overflow-y-auto">
-        {" "}
-        <div className="flex justify-between items-center mb-6">
-          <h1 className="text-xl font-semibold">Orders</h1>
-          <div className="flex gap-4 items-center">
-            <div className="flex items-center gap-2 text-gray-500 border px-3 py-1 rounded">
-              <Calendar className="w-4 h-4" />
-              <span>13 June – 14 July</span>
-            </div>
-            <Button variant="secondary" disabled>
-              Change delivery state
-            </Button>
-          </div>
-        </div>
-        <div className="flex justify-center items-center mt-6 gap-2">
-          {[1, 2, 3, "...", 6].map((num, idx) => (
-            <Button key={idx} variant="ghost" size="sm">
-              {num}
-            </Button>
-          ))}
-        </div>
-      </main>
+    <div className="flex">
+      <Board />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add FoodRouter on backend with endpoints to list and create food items
- expose new route in server
- implement admin menu page fetching food list
- simplify admin home page to show board component
- fix admin layout import case

## Testing
- `npm run build` in `BE-food-delivery`
- `npm run lint` in `fe-food-delivery` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cc89ad5d88333aff2ed2dde960956