### PR TITLE
Implement food creation on admin menu

### DIFF
--- a/fe-food-delivery/src/app/admin/menu/AddFoodDialog.tsx
+++ b/fe-food-delivery/src/app/admin/menu/AddFoodDialog.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Formik, Form, Field, ErrorMessage } from "formik";
+import * as yup from "yup";
+import api from "@/lib/api";
+
+interface Props {
+  onAdd: (food: any) => void;
+}
+
+export default function AddFoodDialog({ onAdd }: Props) {
+  const [open, setOpen] = useState(false);
+
+  const FoodSchema = yup.object().shape({
+    foodName: yup.string().required("Food name is required"),
+    price: yup
+      .number()
+      .typeError("Price must be a number")
+      .required("Price is required"),
+    image: yup.string().url("Invalid image url").required("Image is required"),
+    ingriedents: yup.string().required("Ingredients are required"),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>Add Food</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add New Food</DialogTitle>
+        </DialogHeader>
+        <Formik
+          initialValues={{ foodName: "", price: "", image: "", ingriedents: "" }}
+          validationSchema={FoodSchema}
+          onSubmit={async (values, { setSubmitting, resetForm }) => {
+            try {
+              const res = await api.post("/food", {
+                foodName: values.foodName,
+                price: Number(values.price),
+                image: values.image,
+                ingriedents: values.ingriedents,
+              });
+              onAdd(res.data.food);
+              resetForm();
+              setOpen(false);
+            } catch (err: any) {
+              alert(err.response?.data?.message || "Failed to create food");
+            } finally {
+              setSubmitting(false);
+            }
+          }}
+        >
+          {({ isSubmitting, isValid, dirty }) => (
+            <Form className="space-y-4">
+              <div className="space-y-1">
+                <Field name="foodName" as={Input} placeholder="Food name" />
+                <ErrorMessage name="foodName" component="div" className="text-red-500 text-sm" />
+              </div>
+              <div className="space-y-1">
+                <Field name="price" as={Input} placeholder="Price" />
+                <ErrorMessage name="price" component="div" className="text-red-500 text-sm" />
+              </div>
+              <div className="space-y-1">
+                <Field name="image" as={Input} placeholder="Image URL" />
+                <ErrorMessage name="image" component="div" className="text-red-500 text-sm" />
+              </div>
+              <div className="space-y-1">
+                <Field name="ingriedents" as={Input} placeholder="Ingredients" />
+                <ErrorMessage name="ingriedents" component="div" className="text-red-500 text-sm" />
+              </div>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button type="button" variant="outline">
+                    Cancel
+                  </Button>
+                </DialogClose>
+                <Button type="submit" disabled={!isValid || !dirty || isSubmitting}>
+                  {isSubmitting ? "Saving..." : "Save"}
+                </Button>
+              </DialogFooter>
+            </Form>
+          )}
+        </Formik>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/fe-food-delivery/src/app/admin/menu/page.tsx
+++ b/fe-food-delivery/src/app/admin/menu/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import api from "@/lib/api";
+import AddFoodDialog from "./AddFoodDialog";
 
 export default function AdminFoodMenuPage() {
   const [foods, setFoods] = useState<any[]>([]);
@@ -25,7 +26,10 @@ export default function AdminFoodMenuPage() {
   return (
     <div className="flex h-screen bg-gray-100 text-sm">
       <main className="flex-1 p-8 overflow-y-auto">
-        <h1 className="text-xl font-semibold mb-4">Food menu</h1>
+        <div className="flex items-center justify-between mb-4">
+          <h1 className="text-xl font-semibold">Food menu</h1>
+          <AddFoodDialog onAdd={(f) => setFoods((prev) => [...prev, f])} />
+        </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {loading ? (
             <p>Loading...</p>


### PR DESCRIPTION
## Summary
- add dialog to create new food items
- use dialog on admin food menu page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ccb5813508333b3aa1fe2db6dadae