### PR TITLE
Fix admin menu logic

### DIFF
--- a/fe-food-delivery/src/app/admin/menu/AddFoodDialog.tsx
+++ b/fe-food-delivery/src/app/admin/menu/AddFoodDialog.tsx
@@ -21,7 +21,7 @@ interface Props {
   onAdd: (food: any) => void;
 }
 
-export default function AddNewFoodCardWithDialog({ category, onAdd }: Props) {
+export default function AddFoodDialog({ category, onAdd }: Props) {
   const [open, setOpen] = useState(false);
 
   const FoodSchema = yup.object().shape({


### PR DESCRIPTION
## Summary
- rename component to `AddFoodDialog`
- improve admin menu page with categories and ability to add items

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p fe-food-delivery/tsconfig.json` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685cd01db1bc8333ac43b0e32c72a8fe