### PR TITLE
Fix upload route imports and types

### DIFF
--- a/BE-food-delivery/controllers/upload/uploadImage.ts
+++ b/BE-food-delivery/controllers/upload/uploadImage.ts
@@ -8,7 +8,8 @@ interface UploadRequest extends Request {
 
 export const uploadImage = async (req: UploadRequest, res: Response) => {
   if (!req.file || !req.file.buffer) {
-    return res.status(400).json({ error: "No file provided" });
+    res.status(400).json({ error: "No file provided" });
+    return;
   }
 
   try {
@@ -27,12 +28,14 @@ export const uploadImage = async (req: UploadRequest, res: Response) => {
           }
         );
 
-        stream.end(req.file.buffer); // ✅ send buffer to cloudinary
+        stream.end(req.file!.buffer); // ✅ send buffer to cloudinary
       }
     );
 
-    return res.json({ url: result.secure_url });
+    res.json({ url: result.secure_url });
+    return;
   } catch (err: any) {
-    return res.status(500).json({ error: err.message || "Upload failed" });
+    res.status(500).json({ error: err.message || "Upload failed" });
+    return;
   }
 };

--- a/BE-food-delivery/routes/upload.route.ts
+++ b/BE-food-delivery/routes/upload.route.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import multer from "multer";
-import { uploadImage } from "../controllers/upload/UploadImage";
+import { uploadImage } from "../controllers/upload/uploadImage";
 
 const router = express.Router();
 const storage = multer.memoryStorage();


### PR DESCRIPTION
## Summary
- fix case-sensitive path in upload route
- handle optional file type in `uploadImage`

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build` (fails: `next: not found`)


------
https://chatgpt.com/codex/tasks/task_e_685e20d8a120833381f0214d042d0860