### PR TITLE
Use remote API URL

### DIFF
--- a/fe-food-delivery/src/app/signup/_components/LeftStep_2.tsx
+++ b/fe-food-delivery/src/app/signup/_components/LeftStep_2.tsx
@@ -40,7 +40,7 @@ export const LeftStep2 = ({ onBack, email }: LeftStep2Props) => {
       onSubmit={async (values, { setSubmitting }) => {
         try {
           const response = await axios.post(
-            "http://localhost:8000/api/auth/signup",
+            "https://food-delivery-1-89kz.onrender.com/api/auth/signup",
             {
               email,
               password: values.pass,

--- a/fe-food-delivery/src/app/signup/_components/hooks/axios.ts
+++ b/fe-food-delivery/src/app/signup/_components/hooks/axios.ts
@@ -2,7 +2,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: "http://localhost:8000/api/auth",
+  baseURL: "https://food-delivery-1-89kz.onrender.com/api/auth",
   withCredentials: true,
 });
 

--- a/fe-food-delivery/src/lib/api.ts
+++ b/fe-food-delivery/src/lib/api.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: "http://localhost:8000/api",
+  baseURL: "https://food-delivery-1-89kz.onrender.com/api",
 });
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
- configure frontend axios instances to use the production backend

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686200880ba08333968c803e48a6958f