### PR TITLE
Add configurable API base URL

### DIFF
--- a/fe-food-delivery/README.md
+++ b/fe-food-delivery/README.md
@@ -14,6 +14,10 @@ pnpm dev
 bun dev
 ```
 
+### Environment Setup
+
+Copy `env.example` to `.env.local` and set `NEXT_PUBLIC_API_BASE_URL` to your backend API's base URL.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/fe-food-delivery/env.example
+++ b/fe-food-delivery/env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+

--- a/fe-food-delivery/src/app/signup/_components/LeftStep_2.tsx
+++ b/fe-food-delivery/src/app/signup/_components/LeftStep_2.tsx
@@ -6,7 +6,7 @@ import { ChevronLeft } from "lucide-react";
 import { Formik, Form, Field, ErrorMessage } from "formik";
 import * as yup from "yup";
 import { useState } from "react";
-import axios from "axios";
+import api from "./hooks/axios";
 import { useRouter } from "next/navigation";
 
 const FormSchema = yup.object().shape({
@@ -39,13 +39,10 @@ export const LeftStep2 = ({ onBack, email }: LeftStep2Props) => {
       validationSchema={FormSchema}
       onSubmit={async (values, { setSubmitting }) => {
         try {
-          const response = await axios.post(
-            "https://food-delivery-1-89kz.onrender.com/api/auth/signup",
-            {
-              email,
-              password: values.pass,
-            }
-          );
+          const response = await api.post("/signup", {
+            email,
+            password: values.pass,
+          });
           alert(response.data.message);
           // Maybe redirect after signup?
           router.push("/login");

--- a/fe-food-delivery/src/app/signup/_components/hooks/axios.ts
+++ b/fe-food-delivery/src/app/signup/_components/hooks/axios.ts
@@ -2,7 +2,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: "https://food-delivery-1-89kz.onrender.com/api/auth",
+  baseURL: `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/auth`,
   withCredentials: true,
 });
 

--- a/fe-food-delivery/src/lib/api.ts
+++ b/fe-food-delivery/src/lib/api.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: "https://food-delivery-1-89kz.onrender.com/",
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
 });
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
- create `env.example` with `NEXT_PUBLIC_API_BASE_URL`
- read `NEXT_PUBLIC_API_BASE_URL` in API helper
- update signup axios helper to use env config
- wire signup password step to axios helper
- document environment setup for base URL

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686204c8dda08333836b46b026c22ffa